### PR TITLE
Added Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,10 +3,6 @@
 This document outlines security procedures and general policies for the `OnDemand`
 project.
 
-  * [Reporting a Bug](#reporting-a-bug)
-  * [Disclosure Policy](#disclosure-policy)
-  * [Comments on this Policy](#comments-on-this-policy)
-
 ## Reporting a Bug
 
 If you have security concerns or think you have found a vulnerability in Open OnDemand,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the `OnDemand`
+project.
+
+  * [Reporting a Bug](#reporting-a-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+If you have security concerns or think you have found a vulnerability in Open OnDemand,
+please contact us directly via email on the news list found [here](https://lists.osu.edu/mailman/listinfo/ood-users).
+
+Your email will be answered promptly by one of our developers.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
I've added a basic SECURITY.md policy pulling details from the http://openondemand.org/ site. A maintainer should expand the Disclosure Policy and the Comments on this Policy to make sure it aligns with the project's policies. 

Adding this file makes the Security tab on Github usable but Advisories will need to be enabled if that's something the team wants to leverage. 